### PR TITLE
Update output syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,13 @@ jobs:
   # Set the name of the environment based on the branch.
   # This is used to set the deployment stage at AWS.
   determine-stage:
-    outputs:
-      deployment-stage: ${{ steps.deployment-stage.outputs.env }}
     runs-on: ubuntu-latest
+    outputs:
+      deployment-stage: ${{ steps.deployment-stage.outputs.stage }}
     steps:
       - name: Set up deployment stage name
         id: deployment-stage
-        run: |
-          echo "::set-output name=env::${{ fromJSON('{"main":"prod","dev":"dev","test":"test"}')[github.ref_name] }}"
+        run: echo "stage=${{ fromJSON('{"main":"prod","dev":"dev","test":"test"}')[github.ref_name] }}" >> $GITHUB_ENV
   
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes a warning from github about a deprecated syntax for values shared between jobs. See for fix: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs