### PR TITLE
Include image header in image payload

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -114,7 +114,7 @@ class Image(Base):
 
             "username": self.username,
             "user_id": self.user_id,
-            "header": json.loads(self.header)
+            "header": json.loads(self.header) if self.header is not None else self.header
         }
 
         # Convert to timestamp in milliseconds

--- a/api/db.py
+++ b/api/db.py
@@ -114,6 +114,7 @@ class Image(Base):
 
             "username": self.username,
             "user_id": self.user_id,
+            "header": self.header
         }
 
         # Convert to timestamp in milliseconds

--- a/api/db.py
+++ b/api/db.py
@@ -114,7 +114,7 @@ class Image(Base):
 
             "username": self.username,
             "user_id": self.user_id,
-            "header": self.header
+            "header": json.loads(self.header)
         }
 
         # Convert to timestamp in milliseconds


### PR DESCRIPTION
This small change includes the entire image header when fetching images.

We require the entire image header now because we are grouping images based on the SMARTSTK keyword, which specifies a unique ID to group related images together.

This PR simply serializes the header column in the image object to the client, and only adds data to the API response so is backwards compatible with the current production UI. This PR must be merged and deployed prior to https://github.com/LCOGT/ptr_ui/pull/96 being merged and deployed.