### PR TITLE
Fix/api-issue

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -114,7 +114,8 @@ class Image(Base):
 
             "username": self.username,
             "user_id": self.user_id,
-            "header": json.loads(self.header) if self.header is not None else self.header
+            "SMARTSTK": self.header.SMARTSTK if self.header is not None else '',
+            "SSTKNUM": self.header.SSTKNUM if self.header is not None else ''
         }
 
         # Convert to timestamp in milliseconds

--- a/api/db.py
+++ b/api/db.py
@@ -115,8 +115,8 @@ class Image(Base):
 
             "username": self.username,
             "user_id": self.user_id,
-            "SMARTSTK": header_dictionary["SMARTSTK"] if self.header is not None else '',
-            "SSTKNUM": header_dictionary["SSTKNUM"] if self.header is not None else ''
+            "SMARTSTK": header_dictionary.get("SMARTSTK", '') if self.header is not None else '',
+            "SSTKNUM": header_dictionary.get("SSTKNUM", '') if self.header is not None else ''
         }
 
         # Convert to timestamp in milliseconds

--- a/api/db.py
+++ b/api/db.py
@@ -90,7 +90,7 @@ class Image(Base):
         Notably missing from this is the entire fits header, for smaller 
         payload sizes.
         """
-        header_dictionary = json.loads(self.header)
+        header_dictionary = json.loads(self.header) if self.header is not None else None
 
         package = {
             "image_id": self.image_id,
@@ -115,8 +115,8 @@ class Image(Base):
 
             "username": self.username,
             "user_id": self.user_id,
-            "SMARTSTK": header_dictionary.get("SMARTSTK", '') if self.header is not None else '',
-            "SSTKNUM": header_dictionary.get("SSTKNUM", '') if self.header is not None else ''
+            "SMARTSTK": header_dictionary.get("SMARTSTK", '') if header_dictionary is not None else '',
+            "SSTKNUM": header_dictionary.get("SSTKNUM", '') if header_dictionary is not None else ''
         }
 
         # Convert to timestamp in milliseconds

--- a/api/db.py
+++ b/api/db.py
@@ -115,8 +115,8 @@ class Image(Base):
 
             "username": self.username,
             "user_id": self.user_id,
-            "SMARTSTK": header_dictionary.SMARTSTK if self.header is not None else '',
-            "SSTKNUM": header_dictionary.SSTKNUM if self.header is not None else ''
+            "SMARTSTK": header_dictionary["SMARTSTK"] if self.header is not None else '',
+            "SSTKNUM": header_dictionary["SSTKNUM"] if self.header is not None else ''
         }
 
         # Convert to timestamp in milliseconds

--- a/api/db.py
+++ b/api/db.py
@@ -90,6 +90,7 @@ class Image(Base):
         Notably missing from this is the entire fits header, for smaller 
         payload sizes.
         """
+        header_dictionary = json.loads(self.header)
 
         package = {
             "image_id": self.image_id,
@@ -114,8 +115,8 @@ class Image(Base):
 
             "username": self.username,
             "user_id": self.user_id,
-            "SMARTSTK": self.header.SMARTSTK if self.header is not None else '',
-            "SSTKNUM": self.header.SSTKNUM if self.header is not None else ''
+            "SMARTSTK": header_dictionary.SMARTSTK if self.header is not None else '',
+            "SSTKNUM": header_dictionary.SSTKNUM if self.header is not None else ''
         }
 
         # Convert to timestamp in milliseconds


### PR DESCRIPTION
### FIX: Not sending entire image header to backend

### DESCRIPTION


**Background:**

Occasionally, images at certain sites wouldn't load and the user could only see the placeholder image. This issue was raised by Michael [here](https://lcogt.slack.com/archives/CLAQ9U79B/p1697583762292049). After investigating CloudWatch with @mgdaily, we found that the api request was returning `413 errors` because there was too much data to return. The problem here was that we were sending the entire image header to the backend when really, all we needed from the header was `SMARTSTK` and `SSTKNUM` to be able to group images. 



**Implementation:**

With the extensive help of @mgdaily, we created a variable called `header_dictionary` that parses `header` into a dictionary. This way, we can more cleanly `get` `SMARTSTK` and `SSTKNUM` from the `header_dictionary`. We also added existence and safety checks to prevent errors. By only returning these two values rather than the entire header object, we're significantly reducing the amount of data that we send and return, presumably preventing `413 errors`\

You can see the UI PR related to this issue [here](https://github.com/LCOGT/ptr_ui/pull/112#issue-1954821498). 