### PR TITLE
Update/smtstk image fetching optimization

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -288,8 +288,17 @@ def filtered_images_query(db_address: str, query_filters: list):
             .all()
         session.expunge_all()
     image_pkgs = [image.get_image_pkg() for image in images]
+    image_pkgs = list(filter(filter_img_pkgs_final_sstack, image_pkgs))
     return image_pkgs
 
+# Filter removes intermediate smart stacks to reduce the size of payload sent to the ui
+def filter_img_pkgs_final_sstack(img_pkg):
+    try:
+        if img_pkg["SMARTSTK"] == 'no' or img_pkg["SMARTSTK"] == img_pkg["SSTKNUM"]:
+            return True
+        return False
+    except KeyError :
+        return True
 
 def get_image_by_filename(db_address, base_filename):
     """Gets the image package for the image specified by the filename.

--- a/api/db.py
+++ b/api/db.py
@@ -291,7 +291,7 @@ def filtered_images_query(db_address: str, query_filters: list):
     image_pkgs = list(filter(filter_img_pkgs_final_sstack, image_pkgs))
     return image_pkgs
 
-# Filter removes intermediate smart stacks to reduce the size of payload sent to the ui
+# Filter smart stacks to reduce the size of ui payload
 def filter_img_pkgs_final_sstack(img_pkg):
     try:
         if img_pkg["SMARTSTK"] == 'no' or img_pkg["SMARTSTK"] == img_pkg["SSTKNUM"]:


### PR DESCRIPTION
Problem: payload to the ui contained intermediate smart stacks even though the ui filtered them out and we didn't use them.

Goal: remove intermediate smart stack images from payload in the backend

Solution: wrote a function filter_img_pkgs_final_sstack() that would keep only the final smart stack image and non smart stack images in the list that is eventually sent back to the front end. This pr will also be paired with another pr to ptr_ui that will remove the intermediate smart stack checking there. 