### PR TITLE
updated imports

### DIFF
--- a/api/events_handler.py
+++ b/api/events_handler.py
@@ -13,9 +13,8 @@ from pytz.exceptions import UnknownTimeZoneError
 
 from api.events import make_site_events
 from api.events import get_moon_riseset_illum
-from helpers import BUCKET_NAME, REGION, S3_PUT_TTL, S3_GET_TTL
-from helpers import dynamodb_r, ssm_c
-from helpers import DecimalEncoder, http_response, _get_body, get_secret, get_db_connection
+from api.helpers import dynamodb_r
+from api.helpers import http_response
 
 log = logging.getLogger()
 log.setLevel(logging.INFO)


### PR DESCRIPTION
## QUICK FIX: Updated imports
**Background:**
The moon events were not working because the api request was returning a `502` error. This was because files were not being properly imported.

**Implementation:**
Changed imports from `from helpers import http_response` to `from api.helpers import http_response` 
Shout out to Matt, great leader and mentor